### PR TITLE
docs: added news updated version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: connector
 Title: Connect to your data easily
-Version: 0.0.0.9000
+Version: 0.0.1
 Authors@R: c(
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# NNaccess 0.0.1
+
+* Initial release to internal package manager


### PR DESCRIPTION
In order to release to the internal package manager the package needs to be in version 0.0.1 and have a news file