### PR TITLE
Issue 105

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: connector
 Title: Streamlining Data Access in Clinical Research
-Version: 0.1.1.9000
+Version: 0.1.1.9002
 Authors@R: c(
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
-# connector 0.1.1.9000 (development version)
+# connector 0.1.1.9002 (development version)
 
 ## Enhancements
 * Added upload_cnt and download_cnt methods for ConnectorLogger
+
+## Bugs
+
+* Fixed bug in connectors function. You can now pass a R Object.
 
 ## Other
 * Reformat code with air

--- a/R/connector.R
+++ b/R/connector.R
@@ -174,3 +174,8 @@ print_cnt <- function(connector_object) {
 
   return(invisible(connector_object))
 }
+
+#' @noRd
+is_connector <- function(connector) {
+  inherits(connector, "Connector")
+}

--- a/R/conts_datasources.R
+++ b/R/conts_datasources.R
@@ -12,9 +12,18 @@ connectors_to_datasources <- function(data) {
     as.list() |>
     purrr::imap(
       ~ {
-        deparse(.x) |>
-          extract_function_info() |>
-          transform_as_backend(.y)
+        if(is_symbol(.x)){
+          list(
+            name = as.character(.x),
+            backend = list(
+              type= "NA; R object instead of a call."
+            )
+          )
+        }else{
+          deparse(.x) |>
+            extract_function_info() |>
+            transform_as_backend(.y)
+        }
       }
     ) |>
     unname() |>

--- a/tests/testthat/_snaps/connector.md
+++ b/tests/testthat/_snaps/connector.md
@@ -106,3 +106,115 @@
       [18] "Specifications:"                                         
       [19] "\033[36m•\033[39m path: ."                               
 
+# can create Connector object [plain]
+
+    Code
+      test
+    Output
+       [1] ""                                                                                
+       [2] "-- Datasources -----------------------------------------------------------------"
+       [3] ""                                                                                
+       [4] "-- test --"                                                                      
+       [5] ""                                                                                
+       [6] "* Backend Type: \"NA; R object instead of a call.\""                             
+       [7] ""                                                                                
+       [8] "-- test_2 --"                                                                    
+       [9] ""                                                                                
+      [10] "* Backend Type: \"base::as.data.frame\""                                         
+      [11] "* x: \"iris\""                                                                   
+      [12] ""                                                                                
+      [13] "-- Datasources -----------------------------------------------------------------"
+      [14] ""                                                                                
+      [15] "-- test --"                                                                      
+      [16] ""                                                                                
+      [17] "* Backend Type: \"NA; R object instead of a call.\""                             
+      [18] ""                                                                                
+      [19] "-- test_2 --"                                                                    
+      [20] ""                                                                                
+      [21] "* Backend Type: \"base::as.data.frame\""                                         
+      [22] "* x: \"iris\""                                                                   
+
+# can create Connector object [ansi]
+
+    Code
+      test
+    Output
+       [1] ""                                                                                                                               
+       [2] "\033[36m--\033[39m \033[1mDatasources\033[22m \033[36m-----------------------------------------------------------------\033[39m"
+       [3] ""                                                                                                                               
+       [4] "-- \033[1m\033[1mtest\033[1m\033[22m --"                                                                                        
+       [5] ""                                                                                                                               
+       [6] "* Backend Type: \033[34m\"NA; R object instead of a call.\"\033[39m"                                                            
+       [7] ""                                                                                                                               
+       [8] "-- \033[1m\033[1mtest_2\033[1m\033[22m --"                                                                                      
+       [9] ""                                                                                                                               
+      [10] "* Backend Type: \033[34m\"base::as.data.frame\"\033[39m"                                                                        
+      [11] "* x: \033[34m\"iris\"\033[39m"                                                                                                  
+      [12] ""                                                                                                                               
+      [13] "\033[36m--\033[39m \033[1mDatasources\033[22m \033[36m-----------------------------------------------------------------\033[39m"
+      [14] ""                                                                                                                               
+      [15] "-- \033[1m\033[1mtest\033[1m\033[22m --"                                                                                        
+      [16] ""                                                                                                                               
+      [17] "* Backend Type: \033[34m\"NA; R object instead of a call.\"\033[39m"                                                            
+      [18] ""                                                                                                                               
+      [19] "-- \033[1m\033[1mtest_2\033[1m\033[22m --"                                                                                      
+      [20] ""                                                                                                                               
+      [21] "* Backend Type: \033[34m\"base::as.data.frame\"\033[39m"                                                                        
+      [22] "* x: \033[34m\"iris\"\033[39m"                                                                                                  
+
+# can create Connector object [unicode]
+
+    Code
+      test
+    Output
+       [1] ""                                                                                
+       [2] "── Datasources ─────────────────────────────────────────────────────────────────"
+       [3] ""                                                                                
+       [4] "── test ──"                                                                      
+       [5] ""                                                                                
+       [6] "• Backend Type: \"NA; R object instead of a call.\""                             
+       [7] ""                                                                                
+       [8] "── test_2 ──"                                                                    
+       [9] ""                                                                                
+      [10] "• Backend Type: \"base::as.data.frame\""                                         
+      [11] "• x: \"iris\""                                                                   
+      [12] ""                                                                                
+      [13] "── Datasources ─────────────────────────────────────────────────────────────────"
+      [14] ""                                                                                
+      [15] "── test ──"                                                                      
+      [16] ""                                                                                
+      [17] "• Backend Type: \"NA; R object instead of a call.\""                             
+      [18] ""                                                                                
+      [19] "── test_2 ──"                                                                    
+      [20] ""                                                                                
+      [21] "• Backend Type: \"base::as.data.frame\""                                         
+      [22] "• x: \"iris\""                                                                   
+
+# can create Connector object [fancy]
+
+    Code
+      test
+    Output
+       [1] ""                                                                                                                               
+       [2] "\033[36m──\033[39m \033[1mDatasources\033[22m \033[36m─────────────────────────────────────────────────────────────────\033[39m"
+       [3] ""                                                                                                                               
+       [4] "── \033[1m\033[1mtest\033[1m\033[22m ──"                                                                                        
+       [5] ""                                                                                                                               
+       [6] "• Backend Type: \033[34m\"NA; R object instead of a call.\"\033[39m"                                                            
+       [7] ""                                                                                                                               
+       [8] "── \033[1m\033[1mtest_2\033[1m\033[22m ──"                                                                                      
+       [9] ""                                                                                                                               
+      [10] "• Backend Type: \033[34m\"base::as.data.frame\"\033[39m"                                                                        
+      [11] "• x: \033[34m\"iris\"\033[39m"                                                                                                  
+      [12] ""                                                                                                                               
+      [13] "\033[36m──\033[39m \033[1mDatasources\033[22m \033[36m─────────────────────────────────────────────────────────────────\033[39m"
+      [14] ""                                                                                                                               
+      [15] "── \033[1m\033[1mtest\033[1m\033[22m ──"                                                                                        
+      [16] ""                                                                                                                               
+      [17] "• Backend Type: \033[34m\"NA; R object instead of a call.\"\033[39m"                                                            
+      [18] ""                                                                                                                               
+      [19] "── \033[1m\033[1mtest_2\033[1m\033[22m ──"                                                                                      
+      [20] ""                                                                                                                               
+      [21] "• Backend Type: \033[34m\"base::as.data.frame\"\033[39m"                                                                        
+      [22] "• x: \033[34m\"iris\"\033[39m"                                                                                                  
+

--- a/tests/testthat/test-connector.R
+++ b/tests/testthat/test-connector.R
@@ -38,3 +38,20 @@ cli::test_that_cli("Test connector creation", {
     expect_snapshot_out(print(connector_obj$test))
   })
 })
+
+cli::test_that_cli("can create Connector object", {
+
+  temp_dir <- withr::local_tempdir("connector_test")
+
+  withr::with_tempdir(tmpdir = temp_dir, {
+
+    test <- ConnectorFS$new(path = ".")
+
+    connector_obj <- connectors(
+      test = test,
+      test_2 = base::as.data.frame(x = iris)
+    )
+
+    expect_snapshot_out(print(datasources(connector_obj)))
+  })
+})


### PR DESCRIPTION
Fix: Support R Objects in connectors() Function

  Problem

The connectors() function failed when passed existing R objects/variables, only working with function calls. This prevented users from creating connectors with pre-existing connector objects.

  Solution

Modified the connectors_to_datasources() function in R/conts_datasources.R to detect and handle R objects (symbols) separately from function calls:

  - Detection: Added is_symbol(.x) check to identify existing R objects
  - Handling: When a symbol is detected, creates a minimal datasource entry with type "NA; R object instead of a call."
  - Fallback: Maintains original behavior for function calls