### PR TITLE
feat: add options or env vars as metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,52 @@ db$database |>
 #> # ℹ 22 more rows
 ```
 
+## Metadata
+
+The `metadata` section in your configuration file defines common variables that can be reused across datasources. This promotes consistency and makes configuration management easier.
+
+### Basic Usage
+
+In your `_connector.yml` file, define metadata variables:
+
+```yaml
+metadata:
+  trial: "demo_trial"
+  root_path: "/data/studies"
+  database_host: "localhost"
+  
+datasources:
+  - name: "adam"
+    backend:
+      type: "connector_fs"
+      path: "{metadata.root_path}/{metadata.trial}/adam"
+```
+
+### Override Methods
+
+You can override metadata values using four methods, in order of precedence:
+
+1. **`connect()` function parameter**: Direct override in R code
+2. **Environment variables**: `CONNECTOR_METADATA_<KEY>` (uppercase)
+3. **R options**: `connector.metadata.<key>` (lowercase)  
+4. **YAML configuration**: Default values in the config file
+
+```r
+# Override using connect() function parameter
+db <- connect("_connector.yml", metadata = list(trial = "prod_trial", root_path = "/prod/data"))
+
+# Override using environment variables
+Sys.setenv(CONNECTOR_METADATA_TRIAL = "prod_trial")
+
+# Override using R options
+options(connector.metadata.root_path = "/prod/data")
+
+# Connect with overridden values
+db <- connect("_connector.yml")
+```
+
+This approach keeps sensitive or environment-specific values out of your configuration files.
+
 ## Useful links
 
 For more information on how to use the package, see the following links:

--- a/man/connect.Rd
+++ b/man/connect.Rd
@@ -63,6 +63,7 @@ withr::with_tempdir({
 # Create dir for the example in tmpdir
 dir.create("example/demo_trial/adam", recursive = TRUE)
 
+
 config <- system.file("config", "_connector.yml", package = "connector")
 
 config
@@ -84,6 +85,13 @@ cnts$sdtm
 
 connect(config, metadata = list(extra_class = "my_class"))
 
+# Override metadata using R options and using environment variables
+withr::with_options(
+ list(connector.metadata.root_path = "custom_path"),
+   code = {
+        dir.create("custom_path/demo_trial/adam", recursive = TRUE)
+        connect(config)
+})
 # Connect only to the adam datasource
 
 connect(config, datasource = "adam")


### PR DESCRIPTION
---
name: PR Template
about: Template for PRs.
title: "[PR] PR name"
labels: ''
assignees: ''

---

 Summary

  Added metadata override functionality that allows users to override metadata values at runtime using environment variables and R options. This enhancement provides flexible configuration management for different
  environments (development, staging, production) while maintaining backward compatibility. The feature includes comprehensive documentation and extensive test coverage.

  Changes Made

  - Added apply_metadata_overrides() function in R/connect.R to handle metadata overrides from environment variables and R options
  - Modified connect() function to automatically apply metadata overrides before processing
  - Enhanced logging with verbose messages to show which metadata values are being overridden
  - Added comprehensive documentation for metadata override functionality
  - Updated README.md with new "Metadata" section explaining basic usage and all override methods
  - Added example in connect() documentation showing R options and environment variable usage
  - Updated man/connect.Rd with new examples demonstrating metadata override functionality
  - Added 112 lines of comprehensive tests in test-connect.R covering all override scenarios

  Related Issues

  - Fixes #112 (metadata override functionality)

  Testing

  - Unit tests for environment variable overrides with case handling
  - Unit tests for R options overrides with precedence validation
  - Integration tests for metadata override precedence order
  - Tests for combining different override methods
  - Tests for new metadata keys added via overrides
  - All existing tests continue to pass

  Checklist

  - Code changes have been tested
  - Documentation has been updated, if applicable
  - All automated tests pass
  - Coding style and naming conventions have been followed
  - The PR is ready for review and merge
