### PR TITLE
fix: remove sas for xpt in the documentation

### DIFF
--- a/R/fs_write.R
+++ b/R/fs_write.R
@@ -98,7 +98,7 @@ write_ext.rds <- function(file, x, ...) {
 }
 
 #' @description
-#' * `sas7bdat`: [haven::write_sas()]
+#' * `xpt`: [haven::write_xpt()]
 #'
 #' @rdname write_file
 #' @export

--- a/man/write_file.Rd
+++ b/man/write_file.Rd
@@ -73,7 +73,7 @@ function to write the file is chosen depending on the file extension.
 }
 
 \itemize{
-\item \code{sas7bdat}: \code{\link[haven:write_sas]{haven::write_sas()}}
+\item \code{xpt}: \code{\link[haven:read_xpt]{haven::write_xpt()}}
 }
 
 \itemize{


### PR DESCRIPTION
close [BUG] haven::write_sas is deprecated #109

