### PR TITLE
fix: breaking cahnge on parameter names for upload and download methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
-# connector 0.1.1.9002 (development version)
+# connector 0.1.1.9004 (development version)
+
+## Breaking Changes
+* **Parameter name changes**: The `upload_cnt()`, `download_cnt()`, `upload_directory_cnt()`, and `download_directory_cnt()` functions now use `src` and `dest` parameters instead of `name`/`file` and `dir`/`name` for consistency across the API. Update your code accordingly:
+  - `upload_cnt(file = "path", name = "target")` → `upload_cnt(src = "path", dest = "target")`
+  - `download_cnt(name = "source", file = "path")` → `download_cnt(src = "source", dest = "path")`
+  - `upload_directory_cnt(dir = "path", name = "target")` → `upload_directory_cnt(src = "path", dest = "target")`
+  - `download_directory_cnt(name = "source", dir = "path")` → `download_directory_cnt(src = "source", dest = "path")`
 
 ## Enhancements
 * Added upload_cnt and download_cnt methods for ConnectorLogger

--- a/R/cnt_generics.R
+++ b/R/cnt_generics.R
@@ -87,12 +87,12 @@ list_content_cnt.default <- function(connector_object, ...) {
 #' Generic implementing of how to download files from a connector:
 #'
 #' @param connector_object `r rd_connector_utils("connector_object")`
-#' @param name `r rd_connector_utils("name")`
-#' @param file `r rd_connector_utils("file")`
+#' @param src `r rd_connector_utils("name")`
+#' @param dest `r rd_connector_utils("file")`
 #' @param ... `r rd_connector_utils("...")`
 #' @return `r rd_connector_utils("inv_connector")`
 #' @export
-download_cnt <- function(connector_object, name, file = basename(name), ...) {
+download_cnt <- function(connector_object, src, dest = basename(src), ...) {
   UseMethod("download_cnt")
 }
 
@@ -107,16 +107,16 @@ download_cnt.default <- function(connector_object, ...) {
 #' Generic implementing of how to upload files to a connector:
 #'
 #' @param connector_object `r rd_connector_utils("connector_object")`
-#' @param file `r rd_connector_utils("file")`
-#' @param name `r rd_connector_utils("name")`
+#' @param src `r rd_connector_utils("file")`
+#' @param dest `r rd_connector_utils("name")`
 #' @param ... `r rd_connector_utils("...")`
 #' @inheritParams connector-options-params
 #' @return `r rd_connector_utils("inv_connector")`
 #' @export
 upload_cnt <- function(
   connector_object,
-  file,
-  name = basename(file),
+  src,
+  dest = basename(src),
   overwrite = zephyr::get_option("overwrite", "connector"),
   ...
 ) {
@@ -176,8 +176,8 @@ remove_directory_cnt.default <- function(connector_object, ...) {
 #' Mostly relevant for file storage connectors.
 #'
 #' @param connector_object `r rd_connector_utils("connector_object")`
-#' @param dir [character] Path to the directory to upload
-#' @param name [character] The name of the new directory to place the content in
+#' @param src [character] Path to the directory to upload
+#' @param dest [character] The name of the new directory to place the content in
 #' @param open `r rd_connector_utils("open")`
 #' @param ... `r rd_connector_utils("...")`
 #' @inheritParams connector-options-params
@@ -185,8 +185,8 @@ remove_directory_cnt.default <- function(connector_object, ...) {
 #' @export
 upload_directory_cnt <- function(
   connector_object,
-  dir,
-  name,
+  src,
+  dest,
   overwrite = zephyr::get_option("overwrite", "connector"),
   open = FALSE,
   ...
@@ -206,12 +206,12 @@ upload_directory_cnt.default <- function(connector_object, ...) {
 #' Mostly relevant for file storage connectors.
 #'
 #' @param connector_object `r rd_connector_utils("connector_object")`
-#' @param name [character] The name of the directory to download
-#' @param dir [character] Path to the directory to download to
+#' @param src [character] The name of the directory to download from the connector
+#' @param dest [character] Path to the directory to download to
 #' @param ... `r rd_connector_utils("...")`
 #' @return `r rd_connector_utils("inv_connector")`
 #' @export
-download_directory_cnt <- function(connector_object, name, dir = name, ...) {
+download_directory_cnt <- function(connector_object, src, dest = basename(src), ...) {
   UseMethod("download_directory_cnt")
 }
 

--- a/R/fs.R
+++ b/R/fs.R
@@ -99,19 +99,23 @@ ConnectorFS <- R6::R6Class(
     #' @description
     #' Download content from the file storage.
     #' See also [download_cnt].
+    #' @param src [character] The name of the file to download from the connector
+    #' @param dest [character] Path to the file to download to
     #' @return `r rd_connector_utils("inv_connector")`
-    download_cnt = function(name, file = basename(name), ...) {
+    download_cnt = function(src, dest = basename(src), ...) {
       self |>
-        download_cnt(name, file, ...)
+        download_cnt(src, dest, ...)
     },
 
     #' @description
     #' Upload a file to the file storage.
     #' See also [upload_cnt].
+    #' @param src [character] Path to the file to upload
+    #' @param dest [character] The name of the file to create
     #' @return `r rd_connector_utils("inv_self")`
-    upload_cnt = function(file, name = basename(file), ...) {
+    upload_cnt = function(src, dest = basename(src), ...) {
       self |>
-        upload_cnt(file, name, ...)
+        upload_cnt(src, dest, ...)
     },
 
     #' @description
@@ -137,23 +141,23 @@ ConnectorFS <- R6::R6Class(
     #' @description
     #' Upload a directory to the file storage.
     #' See also [upload_directory_cnt].
-    #' @param dir [character] The path to the directory to upload
-    #' @param name [character] The name of the directory to create
+    #' @param src [character] The path to the directory to upload
+    #' @param dest [character] The name of the directory to create
     #' @return `r rd_connector_utils("inv_self")`
-    upload_directory_cnt = function(dir, name = basename(dir), ...) {
+    upload_directory_cnt = function(src, dest = basename(src), ...) {
       self |>
-        upload_directory_cnt(dir, name, ...)
+        upload_directory_cnt(src, dest, ...)
     },
 
     #' @description
     #' Download a directory from the file storage.
     #' See also [download_directory_cnt].
-    #' @param name [character] The name of the directory to download
-    #' @param dir [character] The path to the directory to download
+    #' @param src [character] The name of the directory to download from the connector
+    #' @param dest [character] The path to the directory to download to
     #' @return `r rd_connector_utils("inv_connector")`
-    download_directory_cnt = function(name, dir = name, ...) {
+    download_directory_cnt = function(src, dest = basename(src), ...) {
       self |>
-        download_directory_cnt(name, dir, ...)
+        download_directory_cnt(src, dest, ...)
     },
 
     #' @description

--- a/R/fs_methods.R
+++ b/R/fs_methods.R
@@ -159,13 +159,13 @@ remove_cnt.ConnectorFS <- function(connector_object, name, ...) {
 #' @export
 download_cnt.ConnectorFS <- function(
   connector_object,
-  name,
-  file = basename(name),
+  src,
+  dest = basename(src),
   ...
 ) {
-  name <- file.path(connector_object$path, name)
+  src_path <- file.path(connector_object$path, src)
 
-  fs::file_copy(path = name, new_path = file, ...)
+  fs::file_copy(path = src_path, new_path = dest, ...)
 
   return(
     invisible(connector_object)
@@ -201,14 +201,14 @@ download_cnt.ConnectorFS <- function(
 #' @export
 upload_cnt.ConnectorFS <- function(
   connector_object,
-  file,
-  name = basename(file),
+  src,
+  dest = basename(src),
   overwrite = zephyr::get_option("overwrite", "connector"),
   ...
 ) {
-  name <- file.path(connector_object$path, name)
+  dest_path <- file.path(connector_object$path, dest)
 
-  fs::file_copy(path = file, new_path = name, overwrite = overwrite)
+  fs::file_copy(path = src, new_path = dest_path, overwrite = overwrite)
 
   return(
     invisible(connector_object)
@@ -304,15 +304,15 @@ remove_directory_cnt.ConnectorFS <- function(connector_object, name, ...) {
 #' @export
 upload_directory_cnt.ConnectorFS <- function(
   connector_object,
-  dir,
-  name,
+  src,
+  dest,
   overwrite = zephyr::get_option("overwrite", "connector"),
   open = FALSE,
   ...
 ) {
-  name <- file.path(connector_object$path, name)
+  dest_path <- file.path(connector_object$path, dest)
 
-  fs::dir_copy(path = dir, new_path = name, overwrite = overwrite)
+  fs::dir_copy(path = src, new_path = dest_path, overwrite = overwrite)
 
   # create a new connector object from the new path with persistent extra class
   if (open) {
@@ -321,7 +321,7 @@ upload_directory_cnt.ConnectorFS <- function(
       extra_class,
       which(extra_class == "ConnectorFS") - 1
     )
-    connector_object <- connector_fs(name, extra_class)
+    connector_object <- connector_fs(dest_path, extra_class)
   }
 
   return(
@@ -336,13 +336,13 @@ upload_directory_cnt.ConnectorFS <- function(
 #' @export
 download_directory_cnt.ConnectorFS <- function(
   connector_object,
-  name,
-  dir = basename(name),
+  src,
+  dest = basename(src),
   ...
 ) {
-  name <- file.path(connector_object$path, name)
+  src_path <- file.path(connector_object$path, src)
 
-  fs::dir_copy(path = name, new_path = dir, ...)
+  fs::dir_copy(path = src_path, new_path = dest, ...)
 
   return(
     invisible(connector_object)

--- a/R/logger_generics.R
+++ b/R/logger_generics.R
@@ -273,13 +273,13 @@ list_content_cnt.ConnectorLogger <- function(connector_object, ...) {
 #' @export
 upload_cnt.ConnectorLogger <- function(
   connector_object,
-  file,
-  name = basename(file),
+  src,
+  dest = basename(src),
   overwrite = zephyr::get_option("overwrite", "connector"),
   ...
 ) {
   res <- tryCatch(NextMethod())
-  log_write_connector(connector_object, name, ...)
+  log_write_connector(connector_object, dest, ...)
   return(invisible(res))
 }
 
@@ -301,12 +301,12 @@ upload_cnt.ConnectorLogger <- function(
 #' @export
 download_cnt.ConnectorLogger <- function(
   connector_object,
-  name,
-  file = basename(name),
+  src,
+  dest = basename(src),
   ...
 ) {
   res <- tryCatch(NextMethod())
-  log_read_connector(connector_object, name, ...)
+  log_read_connector(connector_object, src, ...)
   return(res)
 }
 

--- a/man/ConnectorFS.Rd
+++ b/man/ConnectorFS.Rd
@@ -101,15 +101,15 @@ Initializes the connector for file storage.
 Download content from the file storage.
 See also \link{download_cnt}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ConnectorFS$download_cnt(name, file = basename(name), ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ConnectorFS$download_cnt(src, dest = basename(src), ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{name}}{\link{character} Name of the content to read, write, or remove. Typically the table name.}
+\item{\code{src}}{\link{character} The name of the file to download from the connector}
 
-\item{\code{file}}{\link{character} Path to the file to download to or upload from}
+\item{\code{dest}}{\link{character} Path to the file to download to}
 
 \item{\code{...}}{Additional arguments passed to the method for the individual connector.}
 }
@@ -126,15 +126,15 @@ See also \link{download_cnt}.
 Upload a file to the file storage.
 See also \link{upload_cnt}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ConnectorFS$upload_cnt(file, name = basename(file), ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ConnectorFS$upload_cnt(src, dest = basename(src), ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{file}}{\link{character} Path to the file to download to or upload from}
+\item{\code{src}}{\link{character} Path to the file to upload}
 
-\item{\code{name}}{\link{character} Name of the content to read, write, or remove. Typically the table name.}
+\item{\code{dest}}{\link{character} The name of the file to create}
 
 \item{\code{...}}{Additional arguments passed to the method for the individual connector.}
 }
@@ -197,15 +197,15 @@ See also \link{remove_directory_cnt}.
 Upload a directory to the file storage.
 See also \link{upload_directory_cnt}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ConnectorFS$upload_directory_cnt(dir, name = basename(dir), ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ConnectorFS$upload_directory_cnt(src, dest = basename(src), ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{dir}}{\link{character} The path to the directory to upload}
+\item{\code{src}}{\link{character} The path to the directory to upload}
 
-\item{\code{name}}{\link{character} The name of the directory to create}
+\item{\code{dest}}{\link{character} The name of the directory to create}
 
 \item{\code{...}}{Additional arguments passed to the method for the individual connector.}
 }
@@ -222,15 +222,15 @@ See also \link{upload_directory_cnt}.
 Download a directory from the file storage.
 See also \link{download_directory_cnt}.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ConnectorFS$download_directory_cnt(name, dir = name, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ConnectorFS$download_directory_cnt(src, dest = basename(src), ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{name}}{\link{character} The name of the directory to download}
+\item{\code{src}}{\link{character} The name of the directory to download from the connector}
 
-\item{\code{dir}}{\link{character} The path to the directory to download}
+\item{\code{dest}}{\link{character} The path to the directory to download to}
 
 \item{\code{...}}{Additional arguments passed to the method for the individual connector.}
 }

--- a/man/download_cnt.Rd
+++ b/man/download_cnt.Rd
@@ -7,18 +7,18 @@
 \alias{download_cnt.ConnectorLogger}
 \title{Download content from the connector}
 \usage{
-download_cnt(connector_object, name, file = basename(name), ...)
+download_cnt(connector_object, src, dest = basename(src), ...)
 
-\method{download_cnt}{ConnectorFS}(connector_object, name, file = basename(name), ...)
+\method{download_cnt}{ConnectorFS}(connector_object, src, dest = basename(src), ...)
 
-\method{download_cnt}{ConnectorLogger}(connector_object, name, file = basename(name), ...)
+\method{download_cnt}{ConnectorLogger}(connector_object, src, dest = basename(src), ...)
 }
 \arguments{
 \item{connector_object}{\link{Connector} The connector object to use.}
 
-\item{name}{\link{character} Name of the content to read, write, or remove. Typically the table name.}
+\item{src}{\link{character} Name of the content to read, write, or remove. Typically the table name.}
 
-\item{file}{\link{character} Path to the file to download to or upload from}
+\item{dest}{\link{character} Path to the file to download to or upload from}
 
 \item{...}{Additional arguments passed to the method for the individual connector.}
 }

--- a/man/download_directory_cnt.Rd
+++ b/man/download_directory_cnt.Rd
@@ -5,16 +5,16 @@
 \alias{download_directory_cnt.ConnectorFS}
 \title{Download a directory}
 \usage{
-download_directory_cnt(connector_object, name, dir = name, ...)
+download_directory_cnt(connector_object, src, dest = basename(src), ...)
 
-\method{download_directory_cnt}{ConnectorFS}(connector_object, name, dir = basename(name), ...)
+\method{download_directory_cnt}{ConnectorFS}(connector_object, src, dest = basename(src), ...)
 }
 \arguments{
 \item{connector_object}{\link{Connector} The connector object to use.}
 
-\item{name}{\link{character} The name of the directory to download}
+\item{src}{\link{character} The name of the directory to download from the connector}
 
-\item{dir}{\link{character} Path to the directory to download to}
+\item{dest}{\link{character} Path to the directory to download to}
 
 \item{...}{Additional arguments passed to the method for the individual connector.}
 }

--- a/man/upload_cnt.Rd
+++ b/man/upload_cnt.Rd
@@ -9,24 +9,24 @@
 \usage{
 upload_cnt(
   connector_object,
-  file,
-  name = basename(file),
+  src,
+  dest = basename(src),
   overwrite = zephyr::get_option("overwrite", "connector"),
   ...
 )
 
 \method{upload_cnt}{ConnectorFS}(
   connector_object,
-  file,
-  name = basename(file),
+  src,
+  dest = basename(src),
   overwrite = zephyr::get_option("overwrite", "connector"),
   ...
 )
 
 \method{upload_cnt}{ConnectorLogger}(
   connector_object,
-  file,
-  name = basename(file),
+  src,
+  dest = basename(src),
   overwrite = zephyr::get_option("overwrite", "connector"),
   ...
 )
@@ -34,9 +34,9 @@ upload_cnt(
 \arguments{
 \item{connector_object}{\link{Connector} The connector object to use.}
 
-\item{file}{\link{character} Path to the file to download to or upload from}
+\item{src}{\link{character} Path to the file to download to or upload from}
 
-\item{name}{\link{character} Name of the content to read, write, or remove. Typically the table name.}
+\item{dest}{\link{character} Name of the content to read, write, or remove. Typically the table name.}
 
 \item{overwrite}{Overwrite existing content if it exists in the connector?
 See \link{connector-options} for details. Default can be set globally with

--- a/man/upload_directory_cnt.Rd
+++ b/man/upload_directory_cnt.Rd
@@ -7,8 +7,8 @@
 \usage{
 upload_directory_cnt(
   connector_object,
-  dir,
-  name,
+  src,
+  dest,
   overwrite = zephyr::get_option("overwrite", "connector"),
   open = FALSE,
   ...
@@ -16,8 +16,8 @@ upload_directory_cnt(
 
 \method{upload_directory_cnt}{ConnectorFS}(
   connector_object,
-  dir,
-  name,
+  src,
+  dest,
   overwrite = zephyr::get_option("overwrite", "connector"),
   open = FALSE,
   ...
@@ -26,9 +26,9 @@ upload_directory_cnt(
 \arguments{
 \item{connector_object}{\link{Connector} The connector object to use.}
 
-\item{dir}{\link{character} Path to the directory to upload}
+\item{src}{\link{character} Path to the directory to upload}
 
-\item{name}{\link{character} The name of the new directory to place the content in}
+\item{dest}{\link{character} The name of the new directory to place the content in}
 
 \item{overwrite}{Overwrite existing content if it exists in the connector?
 See \link{connector-options} for details. Default can be set globally with

--- a/tests/testthat/test-cnt_logger_generics.R
+++ b/tests/testthat/test-cnt_logger_generics.R
@@ -108,14 +108,14 @@ test_that("ConnectorLogger upload and download methods work with real FS connect
 
   # Test upload_cnt.ConnectorLogger
   test_method_with_logging(
-    upload_cnt(setup$connector, test_file, "uploaded_file.txt"),
+    upload_cnt(setup$connector, test_file, dest = "uploaded_file.txt"),
     "uploaded_file.txt"
   )
   expect_true(file.exists(uploaded_file))
 
   # Test download_cnt.ConnectorLogger
   result <- test_method_with_logging(
-    download_cnt(setup$connector, "uploaded_file.txt", download_path),
+    download_cnt(setup$connector, "uploaded_file.txt", dest = download_path),
     "uploaded_file.txt"
   )
   expect_true(file.exists(download_path))

--- a/tests/testthat/test-fs.R
+++ b/tests/testthat/test-fs.R
@@ -44,19 +44,19 @@ test_that("fs connector", {
   fs$list_content_cnt("new_dir") |>
     expect_vector(ptype = character(), size = 0)
 
-  fs$upload_cnt(file = t_file1, name = "t_file.txt")
+  fs$upload_cnt(src = t_file1, dest = "t_file.txt")
   fs$list_content_cnt("t_file.txt") |>
     expect_vector(ptype = character(), size = 1)
   fs$read_cnt("t_file.txt") |>
     expect_equal("hello")
 
-  fs$download_cnt("t_file.txt", file = t_file2)
+  fs$download_cnt("t_file.txt", dest = t_file2)
   readr::read_lines(t_file2) |>
     expect_equal("hello")
 
   testtxt <- "this is a test"
   writeLines(testtxt, file.path(t_dir2, "test.txt"))
-  fs$upload_directory_cnt(t_dir2, name = "newdir")
+  fs$upload_directory_cnt(t_dir2, dest = "newdir")
   fs$list_content_cnt("newdir") |>
     expect_vector(ptype = character(), size = 1)
   fs$path |>
@@ -64,7 +64,7 @@ test_that("fs connector", {
     readLines() |>
     expect_equal(testtxt)
 
-  fs$download_directory_cnt("newdir", t_dir2) |>
+  fs$download_directory_cnt("newdir", dest = t_dir2) |>
     expect_no_condition()
 
   list.files(t_dir2) |>


### PR DESCRIPTION
  ## Summary

This PR introduces a breaking change to standardize parameter names across file upload and download methods. The upload_cnt(), download_cnt(), upload_directory_cnt(), and download_directory_cnt() functions now use consistent src and dest parameters instead of the previous mixed naming convention of name/file and dir/name. This change improves API consistency and makes the functions more intuitive to use.

  ##   Changes Made

  - Breaking Change: Rename parameters in upload_cnt() from file/name to src/dest
  - Breaking Change: Rename parameters in download_cnt() from name/file to src/dest
  - Breaking Change: Rename parameters in upload_directory_cnt() from dir/name to src/dest
  - Breaking Change: Rename parameters in download_directory_cnt() from name/dir to src/dest
  - Update all R6 class methods in ConnectorFS to use new parameter names
  - Update S3 method implementations in fs_methods.R and logger_generics.R
  - Update documentation and man pages to reflect new parameter names
  - Update unit tests to use new parameter syntax
  - Add breaking change documentation to NEWS.md with migration examples

  ##   Related Issues

  - Fixes #100 (standardize parameter naming for upload/download methods)

   ##  Testing

  - Updated unit tests in test-fs.R to use new src/dest parameter names
  - Updated unit tests in test-cnt_logger_generics.R for ConnectorLogger methods
  - All existing functionality preserved with new parameter names
  - Verified backward compatibility is intentionally broken as this is a breaking change

  Checklist

  - Code changes have been tested
  - Documentation has been updated, if applicable
  - All automated tests pass
  - Coding style and naming conventions have been followed
  - The PR is ready for review and merge
  - Breaking change documented in NEWS.md with migration examples