### PR TITLE
fix: min S7 version dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     readr,
     readxl,
     rlang,
-    S7,
+    S7 (>= 0.2.0),
     utils,
     vroom,
     writexl,


### PR DESCRIPTION
## Summary
Sets minimum version of S7 to 0.2.0 after #136 introduced it.

## Changes Made
- Updated DESCRIPTION with min S7 version

## Related Issues
- Closes #139.

## Testing
- No new tests.

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [ ] The PR is ready for review and merge
