### PR TITLE
chore: pin reusable workflows and postgres image

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,8 +6,4 @@ runs:
     - name: Start local postgres server with Docker
       if: runner.os == 'Linux'
       shell: bash
-      env:
-        POSTGRES_IMAGE: postgres@sha256:4aabea78cf39b90e834caf3af7d602a18565f6fe2508705c8d01aa63245c2e20 # v18.4
-      run: |
-       docker pull "$POSTGRES_IMAGE"
-       docker run --name my-postgres --env POSTGRES_PASSWORD=password --publish 5432:5432 --detach "$POSTGRES_IMAGE"
+      run: docker compose -f "${{ github.action_path }}/docker-compose.yaml" up --detach

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,4 +6,6 @@ runs:
     - name: Start local postgres server with Docker
       if: runner.os == 'Linux'
       shell: bash
-      run: docker compose -f "${{ github.action_path }}/docker-compose.yaml" up --detach
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      run: docker compose -f "$ACTION_PATH/docker-compose.yaml" up --detach

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -6,6 +6,8 @@ runs:
     - name: Start local postgres server with Docker
       if: runner.os == 'Linux'
       shell: bash
+      env:
+        POSTGRES_IMAGE: postgres@sha256:4aabea78cf39b90e834caf3af7d602a18565f6fe2508705c8d01aa63245c2e20 # v18.4
       run: |
-       docker pull postgres
-       docker run --name my-postgres --env POSTGRES_PASSWORD=password --publish 5432:5432 --detach postgres
+       docker pull "$POSTGRES_IMAGE"
+       docker run --name my-postgres --env POSTGRES_PASSWORD=password --publish 5432:5432 --detach "$POSTGRES_IMAGE"

--- a/.github/actions/setup/docker-compose.yaml
+++ b/.github/actions/setup/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  postgres:
+    image: postgres@sha256:4aabea78cf39b90e834caf3af7d602a18565f6fe2508705c8d01aa63245c2e20 # v18.4
+    container_name: my-postgres
+    environment:
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+  - package-ecosystem: "docker-compose"
+    directory: "/.github/actions/setup"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/check_and_co.yaml
+++ b/.github/workflows/check_and_co.yaml
@@ -7,9 +7,7 @@ on:
     branches:
       - main
       - master
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 name: All actions
 env:
   R_KEEP_PKG_SOURCE: true
@@ -17,22 +15,33 @@ env:
 jobs:
   check-current-version:
     name: Check current version
-    uses: >-
-      NovoNordisk-OpenSource/r.workflows/.github/workflows/check_current_version.yaml@main
+    permissions:
+      contents: read
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/check_current_version.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
     with:
       use_local_setup_action: true
   pkgdown:
     name: Pkgdown site
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/pkgdown.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/pkgdown.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
     with:
       use_local_setup_action: true
   coverage:
     name: Coverage report
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/coverage.yaml@main
-    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/coverage.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       use_local_setup_action: true
       use_codecov: true
   megalinter:
     name: Megalinter
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/megalinter.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/megalinter.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0

--- a/.github/workflows/check_and_co.yaml
+++ b/.github/workflows/check_and_co.yaml
@@ -9,9 +9,6 @@ on:
       - master
 permissions: {}
 name: All actions
-env:
-  R_KEEP_PKG_SOURCE: true
-  POSTGRES_PW: ${{secrets.TEST_POSTGRES_DB_PW}}
 jobs:
   check-current-version:
     name: Check current version

--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,0 +1,6 @@
+{
+  "ignore": [
+    "inst/demo_trial/**",
+    "tests/testthat/demo_trial/**"
+  ]
+}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: connector
 Title: Streamlining Data Access in Clinical Research
-Version: 1.0.0.9003
+Version: 1.0.0.9004
 Authors@R: c(
     person("Cervan", "Girard", , "cgid@novonordisk.com", role = c("aut", "cre")),
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = "aut"),


### PR DESCRIPTION
## Summary
Pin all reusable workflows called from `check_and_co.yaml` to the `v0.1.0` tag SHA of `NovoNordisk-OpenSource/r.workflows`, address zizmor findings raised by MegaLinter, pin the postgres container used by the composite setup action to a digest, and add Dependabot config to keep both current.

## Changes Made
- Pin `check_current_version`, `pkgdown`, `coverage`, and `megalinter` reusable workflows to `fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3` (v0.1.0).
- Replace workflow-level `contents: write` / `pull-requests: write` with `permissions: {}` and set the minimum required permissions per job.
- Replace `secrets: inherit` on the coverage job with an explicit `CODECOV_TOKEN` pass-through.
- Move the postgres container in `.github/actions/setup` to a `docker-compose.yaml` pinned by digest (`postgres@sha256:4aabea…` — v18.4), and update the composite step to invoke `docker compose up --detach`.
- Add `.github/dependabot.yml` for weekly `github-actions` and `docker-compose` updates with `chore` commit-message prefix.
- Remove the workflow-level `env:` block from `check_and_co.yaml` — its values did not cross into the reusable workflows, so they were dead.
- Add `.jscpd.json` ignoring `inst/demo_trial/**` and `tests/testthat/demo_trial/**` so MegaLinter's jscpd copy-paste check no longer errors on the duplicated CSV fixtures.

## Related Issues
- N/A

## Testing
- MegaLinter / zizmor findings resolved.
- Existing workflows continue to run on push and pull_request against `main`/`master`.

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
